### PR TITLE
reorder imports, small fixes/formatting changes

### DIFF
--- a/cogs/bikkelpunt.py
+++ b/cogs/bikkelpunt.py
@@ -1,9 +1,11 @@
-import config
-import discord
-from discord.ext import commands
 from datetime import datetime, time
+
 import mysql.connector
 import pytz
+import discord
+from discord.ext import commands
+
+import config
 
 database = mysql.connector.connect(
     host=config.database['host'],

--- a/cogs/channels.py
+++ b/cogs/channels.py
@@ -1,6 +1,6 @@
 import re
-import config
 import requests
+
 import discord
 from discord.ext import commands
 from discord.member import Member
@@ -8,6 +8,8 @@ from jikanpy import Jikan
 from cachecontrol import CacheControl
 from cachecontrol.heuristics import ExpiresAfter
 from cachecontrol.caches.file_cache import FileCache
+
+import config
 
 expires = ExpiresAfter(days=1)
 session = CacheControl(requests.Session(), heuristic=expires, cache=FileCache(config.cache_dir))

--- a/cogs/cots.py
+++ b/cogs/cots.py
@@ -1,14 +1,15 @@
-import config
 import re
 import asyncio
 import operator
-from discord.ext import commands
+
 import requests
-from jikanpy import Jikan
-from jikanpy import APIException
+from discord.ext import commands
+from jikanpy import Jikan, APIException
 from cachecontrol import CacheControl
 from cachecontrol.heuristics import ExpiresAfter
 from cachecontrol.caches.file_cache import FileCache
+
+import config
 
 expires = ExpiresAfter(days=1)
 session = CacheControl(requests.Session(), heuristic=expires, cache=FileCache(config.cache_dir))

--- a/cogs/sotw.py
+++ b/cogs/sotw.py
@@ -1,13 +1,14 @@
-from typing import List
-
-import config
-import discord
-from discord.ext import commands
+import re
 import asyncio
 import datetime
 import operator
-import re
+from typing import List
+
+import discord
+from discord.ext import commands
 import mysql.connector
+
+import config
 
 database = mysql.connector.connect(
     host=config.database['host'],

--- a/discordpy.py
+++ b/discordpy.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
+
 import os
-import config
-from discord.ext import commands
 import time
 
+from discord.ext import commands
+
+import config
 
 bot = commands.Bot(command_prefix=config.commandchar, description='Description')
 
@@ -17,8 +19,7 @@ async def on_message(msg):
     # Writes logs away in folder logs/servername/channelname_date.log
     if config.logging_enabled:
         logfile = 'logs/{}/{}_{}.log'.format(msg.guild, msg.channel, time.strftime('%Y-%m-%d'))
-        if not os.path.exists(os.path.dirname(logfile)):
-            os.makedirs(os.path.dirname(logfile))
+        os.makedirs(os.path.dirname(logfile), exist_ok=True)
         with open(logfile, 'a') as log:
             log.write('{}  <{}> {}\n'.format(
                 time.strftime('%Y-%m-%dT%H:%M:%S'),

--- a/extensions/credits.py
+++ b/extensions/credits.py
@@ -1,5 +1,6 @@
 import sys
 import time
+
 import discord
 from discord.ext import commands
 

--- a/extensions/emojiexport.py
+++ b/extensions/emojiexport.py
@@ -1,8 +1,10 @@
-import config
 import io
 import os
+
 from discord import File
 from discord.ext import commands
+
+import config
 
 
 @commands.command(help='Export a .csv of messages with their emoji count')
@@ -26,7 +28,7 @@ async def export(ctx, channel_id: int = 0):
         return   
     else:
        for message in messageswithReactions:
-            reaction = max(message.reactions, key = lambda k: k.count )
+            reaction = max(message.reactions, key=lambda k: k.count)
             messageContent = message.content.replace(',','\,').replace('\n',' ')
             output.write(f"{reaction.emoji},{reaction.count},{messageContent},{message.author},{message.created_at}{os.linesep}")
 

--- a/extensions/trailer.py
+++ b/extensions/trailer.py
@@ -1,7 +1,6 @@
 from discord.ext import commands
 from jikanpy import Jikan
 
-
 jikan = Jikan()
 
 

--- a/extensions/userexport.py
+++ b/extensions/userexport.py
@@ -1,9 +1,11 @@
-import config
 import io
 import os
+
 from discord import File
 from discord.ext import commands
 from discord.member import Member
+
+import config
 
 
 @commands.command(help='Export a .csv of users who joined a joinable channel')


### PR DESCRIPTION
reordered imports to be more readable, like:

stdlib
third party
relative

Used the `exist_ok` flag on `ok.makedirs` instead of checking before creating for creating the log directory.

Removed the space between the `key` `kwarg` on the `max` call in emojiexport.py.
